### PR TITLE
[ENH] Ownership validation in Post, Reactions and Report routes

### DIFF
--- a/src/controllers/commentReactionController.ts
+++ b/src/controllers/commentReactionController.ts
@@ -1,6 +1,6 @@
 import { Response, Request } from 'express';
 import { Comment, CommentReaction, ReactionType, User } from '@prisma/client';
-import { asyncHandler, formatSuccessResponse } from '../utils/responseHandler';
+import { asyncHandler, formatSuccessResponse, UnauthorizedError } from '../utils/responseHandler';
 import prismaClient from '../services/prisma/prismaClient';
 import validateUserIdentity from '../services/tokenJwtService/validateUserIdentity';
 import { z } from 'zod';
@@ -33,7 +33,7 @@ export const createOrUpdateCommentReaction = asyncHandler(async (req: Request, r
 
     const { authorId, commentId, type } = createSchema.parse(req.body);
 
-    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const createdCommentReaction: CommentReaction & { author: User; comment: Comment } = await prismaClient.commentReaction.upsert({
         where: {
@@ -97,7 +97,7 @@ export const getCommentReaction = asyncHandler(async (req: Request, res: Respons
         },
     });
 
-    if (!validateUserIdentity(commentReaction.authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(commentReaction.authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     res.status(200).json(formatSuccessResponse(commentReaction));
 });
@@ -116,7 +116,7 @@ export const getCommentReactionsByAuthor = asyncHandler(async (req: Request, res
 
     const { authorId } = getSchema.parse(req.body);
 
-    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const commentReactions: (CommentReaction & { author: User; comment: Comment })[] = await prismaClient.commentReaction.findMany({
         where: {
@@ -147,7 +147,7 @@ export const deleteCommentReaction = asyncHandler(async (req: Request, res: Resp
         },
     });
 
-    if (!validateUserIdentity(commentReaction.authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(commentReaction.authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const deletedCommentReaction: CommentReaction = await prismaClient.commentReaction.delete({
         where: {

--- a/src/controllers/commentReportController.ts
+++ b/src/controllers/commentReportController.ts
@@ -1,6 +1,6 @@
 import { Response, Request } from 'express';
 import { CommentReport, Comment, Tag, User } from '@prisma/client';
-import { asyncHandler, formatSuccessResponse } from '../utils/responseHandler';
+import { asyncHandler, formatSuccessResponse, UnauthorizedError } from '../utils/responseHandler';
 import validateUserIdentity from '../services/tokenJwtService/validateUserIdentity';
 import prismaClient from '../services/prisma/prismaClient';
 import { z } from 'zod';
@@ -39,7 +39,7 @@ export const createOrUpdateCommentReport = asyncHandler(async (req: Request, res
 
     const { authorId, commentId, reason, tags } = createSchema.parse(req.body);
 
-    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const createdCommentReport: CommentReport & { comment: Comment; tags: Tag[]; author: User } = await prismaClient.commentReport.upsert({
         where: {
@@ -122,7 +122,7 @@ export const disconnectTagFromCommentReport = asyncHandler(async (req: Request, 
         },
     });
 
-    if (!validateUserIdentity(commentReport.authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(commentReport.authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const updatedCommentReport: CommentReport & { tags: Tag[] } = await prismaClient.commentReport.update({
         where: { id: commentReportId },
@@ -182,7 +182,7 @@ export const getCommentReport = asyncHandler(async (req: Request, res: Response)
             },
         });
 
-    if (!validateUserIdentity(commentReport.authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(commentReport.authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     res.status(200).json(formatSuccessResponse(commentReport));
 });
@@ -201,7 +201,7 @@ export const getCommentReportsByAuthor = asyncHandler(async (req: Request, res: 
 
     const { authorId } = getSchema.parse(req.body);
 
-    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const commentReports: (CommentReport & { comment: Comment; tags: Tag[] })[] = await prismaClient.commentReport.findMany({
         where: {
@@ -232,7 +232,7 @@ export const deleteCommentReport = asyncHandler(async (req: Request, res: Respon
         },
     });
 
-    if (!validateUserIdentity(commentReport.authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(commentReport.authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const deletedCommentReport: CommentReport = await prismaClient.commentReport.delete({
         where: {

--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -1,6 +1,6 @@
 import { Response, Request } from 'express';
 import { z } from 'zod';
-import { asyncHandler, formatSuccessResponse } from '../utils/responseHandler';
+import { asyncHandler, formatSuccessResponse, UnauthorizedError } from '../utils/responseHandler';
 import prismaClient from '../services/prisma/prismaClient';
 import integerValidator from '../utils/integerValidator';
 import validateUserIdentity from '../services/tokenJwtService/validateUserIdentity';
@@ -28,7 +28,7 @@ export const createPost = asyncHandler(async (req: Request, res: Response): Prom
 
     const { title, content, authorId, tags } = createSchema.parse(req.body);
 
-    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const createdPost: Post & { tags: Tag[]; files: File[] } = await prismaClient.post.create({
         data: {
@@ -88,7 +88,7 @@ export const updatePost = asyncHandler(async (req: Request, res: Response): Prom
 
     const { title, content, authorId, tags } = updateSchema.parse(req.body);
 
-    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const updatedPost: Post & { tags: Tag[]; files: File[] } = await prismaClient.post.update({
         where: { id },
@@ -141,7 +141,7 @@ export const disconnectTagFromPost = asyncHandler(async (req: Request, res: Resp
         },
     });
 
-    if (!validateUserIdentity(post.authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(post.authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const updatedPost: Post & { tags: Tag[] } = await prismaClient.post.update({
         where: {
@@ -217,7 +217,7 @@ export const getPostsByAuthor = asyncHandler(async (req: Request, res: Response)
 
     const { authorId } = getSchema.parse(req.body);
 
-    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const posts: (Post & { tags: Tag[]; files: File[] })[] = await prismaClient.post.findMany({
         where: {
@@ -248,7 +248,7 @@ export const deletePost = asyncHandler(async (req: Request, res: Response): Prom
         },
     });
 
-    if (!validateUserIdentity(post.authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(post.authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const deletedPost = await prismaClient.post.delete({
         where: {

--- a/src/controllers/postReactionController.ts
+++ b/src/controllers/postReactionController.ts
@@ -1,6 +1,6 @@
 import { Response, Request } from 'express';
 import { Post, PostReaction, ReactionType, User } from '@prisma/client';
-import { asyncHandler, formatSuccessResponse } from '../utils/responseHandler';
+import { asyncHandler, formatSuccessResponse, UnauthorizedError } from '../utils/responseHandler';
 import prismaClient from '../services/prisma/prismaClient';
 import validateUserIdentity from '../services/tokenJwtService/validateUserIdentity';
 import { z } from 'zod';
@@ -33,7 +33,7 @@ export const createOrUpdatePostReaction = asyncHandler(async (req: Request, res:
 
     const { authorId, postId, type } = createSchema.parse(req.body);
 
-    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const createdPostReaction: PostReaction & { author: User; post: Post } = await prismaClient.postReaction.upsert({
         where: {
@@ -94,7 +94,7 @@ export const getPostReaction = asyncHandler(async (req: Request, res: Response):
         },
     });
 
-    if (!validateUserIdentity(postReaction.authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(postReaction.authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     res.status(200).json(formatSuccessResponse(postReaction));
 });
@@ -113,7 +113,7 @@ export const getPostReactionsByAuthor = asyncHandler(async (req: Request, res: R
 
     const { authorId } = getSchema.parse(req.body);
 
-    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const postReactions: (PostReaction & { author: User; post: Post })[] = await prismaClient.postReaction.findMany({
         where: {
@@ -144,7 +144,7 @@ export const deletePostReaction = asyncHandler(async (req: Request, res: Respons
         },
     });
 
-    if (!validateUserIdentity(postReaction.authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(postReaction.authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const deletedPostReaction: PostReaction = await prismaClient.postReaction.delete({
         where: {

--- a/src/controllers/postReportController.ts
+++ b/src/controllers/postReportController.ts
@@ -2,6 +2,7 @@ import { Response, Request } from 'express';
 import { PostReport, Tag, Post, User } from '@prisma/client';
 import { asyncHandler, formatSuccessResponse } from '../utils/responseHandler';
 import prismaClient from '../services/prisma/prismaClient';
+import validateUserIdentity from '../services/tokenJwtService/validateUserIdentity';
 import { z } from 'zod';
 
 const integerValidator = z
@@ -37,6 +38,8 @@ export const createOrUpdatePostReport = asyncHandler(async (req: Request, res: R
     });
 
     const { authorId, postId, reason, tags } = createSchema.parse(req.body);
+
+    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new Error('Unauthorized user');
 
     const createdPostReport: PostReport & { post: Post; author: User; tags: Tag[] } = await prismaClient.postReport.upsert({
         where: {
@@ -104,6 +107,14 @@ export const disconnectTagFromPostReport = asyncHandler(async (req: Request, res
 
     const { postReportId, tagId } = updateSchema.parse(req.body);
 
+    const postReport = await prismaClient.postReport.findUniqueOrThrow({
+        where: {
+            id: postReportId,
+        },
+    });
+
+    if (!validateUserIdentity(postReport.authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+
     const updatedPostReport: PostReport & { tags: Tag[] } = await prismaClient.postReport.update({
         where: { id: postReportId },
         data: {
@@ -149,7 +160,8 @@ export const getAllPostReports = asyncHandler(async (req: Request, res: Response
  */
 export const getPostReport = asyncHandler(async (req: Request, res: Response): Promise<void> => {
     const id = await integerValidator.parseAsync(req.params.postReportId);
-    const postReport: PostReport & { post: Post; author: User; tags: Tag[] } = await prismaClient.postReport.findUnique({
+
+    const postReport: PostReport & { post: Post; author: User; tags: Tag[] } = await prismaClient.postReport.findUniqueOrThrow({
         where: {
             id,
         },
@@ -159,6 +171,8 @@ export const getPostReport = asyncHandler(async (req: Request, res: Response): P
             tags: true,
         },
     });
+
+    if (!validateUserIdentity(postReport.authorId, req.headers.authorization)) throw new Error('Unauthorized user');
 
     res.status(200).json(formatSuccessResponse(postReport));
 });
@@ -176,6 +190,9 @@ export const getPostReportsByAuthor = asyncHandler(async (req: Request, res: Res
     });
 
     const { authorId } = getSchema.parse(req.body);
+
+    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+
     const postReport: (PostReport & { post: Post })[] = await prismaClient.postReport.findMany({
         where: {
             authorId,
@@ -197,7 +214,16 @@ export const getPostReportsByAuthor = asyncHandler(async (req: Request, res: Res
  */
 export const deletePostReport = asyncHandler(async (req: Request, res: Response): Promise<void> => {
     const id = await integerValidator.parseAsync(req.params.postReportId);
-    const postReport: PostReport = await prismaClient.postReport.delete({ where: { id } });
 
-    res.status(200).json(formatSuccessResponse(postReport));
+    const postReport = await prismaClient.postReport.findUniqueOrThrow({
+        where: {
+            id,
+        },
+    });
+
+    if (!validateUserIdentity(postReport.authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+
+    const deletedPostReport: PostReport = await prismaClient.postReport.delete({ where: { id } });
+
+    res.status(200).json(formatSuccessResponse(deletedPostReport));
 });

--- a/src/controllers/postReportController.ts
+++ b/src/controllers/postReportController.ts
@@ -1,6 +1,6 @@
 import { Response, Request } from 'express';
 import { PostReport, Tag, Post, User } from '@prisma/client';
-import { asyncHandler, formatSuccessResponse } from '../utils/responseHandler';
+import { asyncHandler, formatSuccessResponse, UnauthorizedError } from '../utils/responseHandler';
 import prismaClient from '../services/prisma/prismaClient';
 import validateUserIdentity from '../services/tokenJwtService/validateUserIdentity';
 import { z } from 'zod';
@@ -39,7 +39,7 @@ export const createOrUpdatePostReport = asyncHandler(async (req: Request, res: R
 
     const { authorId, postId, reason, tags } = createSchema.parse(req.body);
 
-    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const createdPostReport: PostReport & { post: Post; author: User; tags: Tag[] } = await prismaClient.postReport.upsert({
         where: {
@@ -113,7 +113,7 @@ export const disconnectTagFromPostReport = asyncHandler(async (req: Request, res
         },
     });
 
-    if (!validateUserIdentity(postReport.authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(postReport.authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const updatedPostReport: PostReport & { tags: Tag[] } = await prismaClient.postReport.update({
         where: { id: postReportId },
@@ -172,7 +172,7 @@ export const getPostReport = asyncHandler(async (req: Request, res: Response): P
         },
     });
 
-    if (!validateUserIdentity(postReport.authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(postReport.authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     res.status(200).json(formatSuccessResponse(postReport));
 });
@@ -191,7 +191,7 @@ export const getPostReportsByAuthor = asyncHandler(async (req: Request, res: Res
 
     const { authorId } = getSchema.parse(req.body);
 
-    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const postReport: (PostReport & { post: Post })[] = await prismaClient.postReport.findMany({
         where: {
@@ -221,7 +221,7 @@ export const deletePostReport = asyncHandler(async (req: Request, res: Response)
         },
     });
 
-    if (!validateUserIdentity(postReport.authorId, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(postReport.authorId, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const deletedPostReport: PostReport = await prismaClient.postReport.delete({ where: { id } });
 

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -2,7 +2,7 @@ import { Response, Request } from 'express';
 import { Role } from '@prisma/client';
 import { z } from 'zod';
 import { hashPassword, verifyPassword } from '../utils/bcryptUtil';
-import { asyncHandler, InternalServerError, UnauthorizedError, formatSuccessResponse} from '../utils/responseHandler';
+import { asyncHandler, InternalServerError, UnauthorizedError, formatSuccessResponse } from '../utils/responseHandler';
 import validateUserIdentity from '../services/tokenJwtService/validateUserIdentity';
 import prismaClient from '../services/prisma/prismaClient';
 import integerValidator from '../utils/integerValidator';
@@ -68,20 +68,22 @@ export const createUser = asyncHandler(async (req: Request, res: Response): Prom
             password,
             role,
             status,
-            courseId
+            courseId,
         },
     });
 
-    res.status(201).json(formatSuccessResponse({
-        user: {
-            id: user.id,
-            name: user.name,
-            email: user.email,
-            role: user.role,
-            status: user.status,
-            courseId: user.courseId,
-        }
-    }));
+    res.status(201).json(
+        formatSuccessResponse({
+            user: {
+                id: user.id,
+                name: user.name,
+                email: user.email,
+                role: user.role,
+                status: user.status,
+                courseId: user.courseId,
+            },
+        })
+    );
 });
 
 /**
@@ -109,17 +111,14 @@ export const updateUser = async (req: Request, res: Response): Promise<void> => 
             password: z.string().min(8).max(255).optional(),
             newPassword: z.string().min(8).max(255).optional(),
         })
-    .refine((data) => 
-    (data.email == data.newEmail) || (data.email && data.newEmail), {
-        message: 'Email cannot be updated as some data is missing',
-        path: ['email', 'newEmail'],
-    }
-    ).refine((data) =>
-        (data.password == data.newPassword) || (data.password && data.newPassword), {
+        .refine((data) => data.email == data.newEmail || (data.email && data.newEmail), {
+            message: 'Email cannot be updated as some data is missing',
+            path: ['email', 'newEmail'],
+        })
+        .refine((data) => data.password == data.newPassword || (data.password && data.newPassword), {
             message: 'Password cannot be updated as some data is missing',
-            path: ['password', 'newPassword']
-        }
-    );
+            path: ['password', 'newPassword'],
+        });
 
     const id = await integerValidator.parseAsync(req.body.tagId);
     const { newName, email, newEmail, newCourseId, password, newPassword } = await updateUserSchema.parseAsync(req.body);
@@ -131,7 +130,7 @@ export const updateUser = async (req: Request, res: Response): Promise<void> => 
     });
 
     // validating if the target user of the update is the same as the token
-    if (!validateUserIdentity(user.email, req.headers.authorization)) throw new Error('Unauthorized user');
+    if (!validateUserIdentity(user.id, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     if (email && email !== user.email) throw new UnauthorizedError('Current email or password is wrong.');
 
@@ -155,14 +154,16 @@ export const updateUser = async (req: Request, res: Response): Promise<void> => 
         },
     });
 
-    res.status(200).json(formatSuccessResponse({
-        user: {
-            id: newUser.id,
-            name: newUser.name,
-            email: newUser.email,
-            courseId: user.courseId,
-        }
-    }));
+    res.status(200).json(
+        formatSuccessResponse({
+            user: {
+                id: newUser.id,
+                name: newUser.name,
+                email: newUser.email,
+                courseId: user.courseId,
+            },
+        })
+    );
 };
 
 /**
@@ -178,16 +179,16 @@ export const deleteUser = asyncHandler(async (req: Request, res: Response): Prom
     const user = await prismaClient.user.findUniqueOrThrow({
         where: {
             id,
-        }
+        },
     });
 
     // validating if the target user of the delete is the same as the token
-    if (!validateUserIdentity(user.email, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
+    if (!validateUserIdentity(user.id, req.headers.authorization)) throw new UnauthorizedError('Unauthorized user');
 
     const deletedUser = await prismaClient.user.delete({
         where: {
-            id: id
-        }
+            id: id,
+        },
     });
 
     res.status(200).json(formatSuccessResponse(deletedUser));


### PR DESCRIPTION
Particularities:
- **Branch diverted from #49  and #65. Do not approve this pull request before the ones mentioned or if the ones mentioned are rejected.**
- The implementation of ownership validation was done in line with what was done in UserController;
- Only create, update, getOne, delete and related routes were protected. Post's getOne route was not protected as there are no private Posts in scope;
- Tag routes were not protected as they are currently unused. They have no ownership relationship and are not used at any time (tags are created nested in other controllers);

Known issues:
- There are no admin power checks. Routes that should be exclusive to administrators are unprotected because they have no ownership relationship;
- 1 code smell resolved in another pull request, 2 not related to my code.